### PR TITLE
Новый пример на Python3 и исправленный sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const http = axios.create({
 ### PHP
 
 ```php
-$url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=exTIBPYTrAKDTHLLm2AwJkmcVcvFCzQUNyoa6wAjvW6k';
+$url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=htQFduJpLxz7ribXRZpDFUH-XEUhC9rBPTJkjUFEkRA';
 $client_secret = 'wvl68m4dR1UpLrVRli'; //Защищённый ключ из настроек вашего приложения
 
 $query_params = [];
@@ -156,7 +156,7 @@ class Application {
     private static final String ENCODING = "UTF-8";
 
     public static void main(String[] args) throws java.lang.Exception {
-        String url = "https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=exTIBPYTrAKDTHLLm2AwJkmcVcvFCzQUNyoa6wAjvW6k";
+        String url = "https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=htQFduJpLxz7ribXRZpDFUH-XEUhC9rBPTJkjUFEkRA";
         String clientSecret = "wvl68m4dR1UpLrVRli";
 
         Map<String, String> queryParams = getQueryParams(new URL(url));
@@ -367,7 +367,7 @@ function verifyLaunchParams(searchOrParsedUrlQuery, secretKey) {
   return paramsHash === sign;
 }
 
-const url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=exTIBPYTrAKDTHLLm2AwJkmcVcvFCzQUNyoa6wAjvW6k';
+const url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=htQFduJpLxz7ribXRZpDFUH-XEUhC9rBPTJkjUFEkRA';
 const clientSecret = 'wvl68m4dR1UpLrVRli'; // Защищённый ключ из настроек вашего приложения
 
 // Берём только параметры запуска.
@@ -467,7 +467,7 @@ function verifyLaunchParams(
   return paramsHash === sign;
 }
 
-const url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=exTIBPYTrAKDTHLLm2AwJkmcVcvFCzQUNyoa6wAjvW6k';
+const url = 'https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=htQFduJpLxz7ribXRZpDFUH-XEUhC9rBPTJkjUFEkRA';
 const clientSecret = 'wvl68m4dR1UpLrVRli'; // Защищённый ключ из настроек вашего приложения
 
 // Берём только параметры запуска.

--- a/README.md
+++ b/README.md
@@ -223,25 +223,64 @@ class Application {
 
 ```python
 from base64 import b64encode
-from collections import OrderedDict
 from hashlib import sha256
 from hmac import HMAC
-from urllib.parse import urlparse, parse_qsl, urlencode
+from urllib.parse import urlparse, parse_qsl, urlencode 
+
+def is_valid(query: dict, secret: str) -> bool:
+    """
+
+    Check VK Apps signature
+
+    :param dict query: Словарь с параметрами запуска
+    :param str secret: Секретный ключ приложения ("Защищённый ключ")
+    :returns: Результат проверки подписи
+    :rtype: bool
+
+    """
+    if not query.get("sign"):
+        return False
+    
+    vk_subset = sorted(
+        filter(
+            lambda key: key.startswith("vk_"), 
+            query
+        )
+    )
+
+    if not vk_subset:
+        return False
+
+    ordered = {k: query[k] for k in vk_subset}
+
+    hash_code = b64encode(
+        HMAC(
+            secret.encode(), 
+            urlencode(ordered, doseq=True).encode(), 
+            sha256
+        ).digest()
+    ).decode("utf-8")
+
+    if hash_code[-1] == "=":
+        hash_code = hash_code[:-1]
+
+    fixed_hash = hash_code.replace('+', '-').replace('/', '_')
+    return query.get("sign") == fixed_hash
 
 
-def is_valid(*, query: dict, secret: str) -> bool:
-    """Check VK Apps signature"""
-    vk_subset = OrderedDict(sorted(x for x in query.items() if x[0][:3] == "vk_"))
-    hash_code = b64encode(HMAC(secret.encode(), urlencode(vk_subset, doseq=True).encode(), sha256).digest())
-    decoded_hash_code = hash_code.decode('utf-8')[:-1].replace('+', '-').replace('/', '_')
-    return query["sign"] == decoded_hash_code
+
+# Пример использования
+
+url = "https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=htQFduJpLxz7ribXRZpDFUH-XEUhC9rBPTJkjUFEkRA"
+client_secret = "wvl68m4dR1UpLrVRli" # Защищённый ключ из настроек вашего приложения
 
 
-url = "https://example.com/?vk_user_id=494075&vk_app_id=6736218&vk_is_app_user=1&vk_are_notifications_enabled=1&vk_language=ru&vk_access_token_settings=&vk_platform=android&sign=exTIBPYTrAKDTHLLm2AwJkmcVcvFCzQUNyoa6wAjvW6k"
-client_secret = "wvl68m4dR1UpLrVRli"  # Защищённый ключ из настроек вашего приложения
-
-# Если без Flask или Django
-query_params = dict(parse_qsl(urlparse(url).query, keep_blank_values=True))
+query_params = dict(
+    parse_qsl(
+        urlparse(url).query, 
+        keep_blank_values=True
+    )
+)
 status = is_valid(query=query_params, secret=client_secret)
 
 print("ok" if status else "fail")


### PR DESCRIPTION
Изначальной целью PR было внести новый пример на Python3, но, после проверки на данных из примера выяснилось, что sign в примерах не совпадает с правильным (которая генерируется как новым примером на Python, так и старыми примерами на Nodejs/Python). 

Поэтому вторым коммитом заменяется параметр sign в во всех примерах.

Изменения в примере на Python3:

1. Старый пример был очень плохо читаемым из-за плохо раскрытых скобок и некоторых других мелочей. Текущий код 

2. Добавлена проверка того, что sign присутствует и не является пустым, а также проверка на наличие параметров, начинающихся с "vk_"

3. Так как начиная с Python 3.6 словари имеют постоянный порядок ключей (а более старые версии Python уже не поддерживаются), `OrderedDict` заменён на обычный `dict`

4. Убрана обязательность keyword-аргументов (* в начале параметров), так как здесь это не имеет особого смысла

5. Вместо `x[:3] == "vk_"` используется `x.startswith("vk_")` (рекомендация PEP8)

6. Вместо сортировки `query.items()` явно используется сортировка ключей (так как сортировка `query.items()` приведёт к тому же, но неявно)

7. Выражение-генератор заменено на `filter` (так как выражение использовалось именно с целью отфильтровать по ключу)


P. S. Сорри за то, что забыл ветку создать, вылетело из головы
